### PR TITLE
Update content-types.json - Added Null type mime XSS

### DIFF
--- a/src/main/resources/json/content-types.json
+++ b/src/main/resources/json/content-types.json
@@ -89,7 +89,7 @@
   {
     "description": "text/vtt",
     "code": "<script>alert(document.domain)<\/script>",
-    "browsers": [
+    "browsers": [.
       "edge"
     ]
   },
@@ -98,6 +98,13 @@
     "code": "<script>alert(document.domain)<\/script>",
     "browsers": [
       "edge"
+    ]
+  },
+  {
+    "description": "#<Mime::NullType:<hex_decimal_memory_address>>; charset=utf-8",
+    "code": "<script>alert(document.domain)</script>",
+    "browsers": [
+      "firefox"
     ]
   }
 ]


### PR DESCRIPTION
In Ruby on Rails, the Mime module is typically used to define MIME types for handling different types of content in HTTP requests and responses. However, the Mime::NullType that you've provided doesn't seem to be a standard MIME type defined within the Ruby on Rails framework.

The firefox browser treats the content types which are not standard as text/html and if the API responds with any random content type(Content-Type: vijaysimha/abcd) with the user payload reflected as it is, then it is possible to get an XSS in the firefox.

This works only in firefox browser and the rest of the browsers treats the non standard content type as plain text.

I have submitted specifically for null type content type since these are generated in Ruby framework